### PR TITLE
raise exception if bing ads api return error

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -20,7 +20,7 @@ import arrow
 import backoff
 from tap_bing_ads import reports
 from tap_bing_ads.exclusions import EXCLUSIONS
-from tap_bing_ads.fetch_ad_accounts import request_customer_id
+from tap_bing_ads.fetch_ad_accounts import request_customer_id, InvalidCredentialsException
 import socket
 
 LOGGER = singer.get_logger()
@@ -1075,8 +1075,11 @@ def main():
     try:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(main_impl())
+    except InvalidCredentialsException as exc:
+        LOGGER.exception(exc)
+        sys.exit(5)
     except Exception as exc:
-        LOGGER.critical(exc)
+        LOGGER.exception(exc)
         raise exc
 
 

--- a/tap_bing_ads/fetch_ad_accounts.py
+++ b/tap_bing_ads/fetch_ad_accounts.py
@@ -9,6 +9,10 @@ logger = logging.getLogger(__name__)
 SOAP_CUSTOMER_MANAGEMENT_URL = "https://clientcenter.api.bingads.microsoft.com/Api/CustomerManagement/v13/CustomerManagementService.svc"
 
 
+class InvalidCredentialsException(Exception):
+    pass
+
+
 def get_field(*fields: str, obj: Dict, default=None) -> Optional[Any]:
     o: Optional[Dict] = obj
     for field in fields:
@@ -73,9 +77,11 @@ def request_customer_id(access_token: str, developer_token: str) -> int:
         "detail",
         "AdApiFaultDetail",
         "Errors",
+        "AdApiError",
         obj=response,
     )
 
-    if error:
-        raise Exception(json.dumps(error))
+    if error and (error.get("Code") in ["105", "109"]):
+        raise InvalidCredentialsException(json.dumps(error))
+
     return int(cast(str, customer_id))

--- a/tap_bing_ads/fetch_ad_accounts.py
+++ b/tap_bing_ads/fetch_ad_accounts.py
@@ -1,7 +1,7 @@
 import requests
 import logging
 import xmltodict
-
+import json
 from typing import Dict, Optional, Any, cast
 
 logger = logging.getLogger(__name__)
@@ -65,4 +65,17 @@ def request_customer_id(access_token: str, developer_token: str) -> int:
         obj=response,
     )
 
+    # The request return 200 even if we fail to get customer_id
+    error = get_field(
+        "s:Envelope",
+        "s:Body",
+        "s:Fault",
+        "detail",
+        "AdApiFaultDetail",
+        "Errors",
+        obj=response,
+    )
+
+    if error:
+        raise Exception(json.dumps(error))
     return int(cast(str, customer_id))


### PR DESCRIPTION
Here is how the error looks like. It returns 200 even if the call was not successful.
![Screenshot 2022-11-14 at 12 52 06](https://user-images.githubusercontent.com/48968138/201653626-cc49380b-7f17-4857-928e-0e62f143bd87.png)
The stacktrace will look like this
![Screenshot 2022-11-14 at 12 54 35](https://user-images.githubusercontent.com/48968138/201653855-66bd414e-8c01-45f5-ad0a-7f8bd076c73c.png)
 I have asked uberall to reconnect bing ads
I am unsure how the automatically notifying customer to reconnect thing works, let me know if I need to use some special exit code or something
