### PR TITLE
S 1673 automatically revoke bing ads

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from tap_bing_ads import main
+
+if __name__ == "__main__":
+    main()

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -12,6 +12,7 @@ from zipfile import ZipFile
 import singer
 from singer import utils, metadata, metrics, Transformer
 from bingads import AuthorizationData, OAuthWebAuthCodeGrant, ServiceClient
+from bingads.exceptions import OAuthTokenRequestException
 import suds
 from suds.sudsobject import asdict
 import stringcase
@@ -1075,6 +1076,9 @@ def main():
     try:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(main_impl())
+    except OAuthTokenRequestException:
+        LOGGER.warn("oauth error", exc_info=True)
+        sys.exit(5)
     except InvalidCredentialsException as exc:
         LOGGER.exception(exc)
         sys.exit(5)


### PR DESCRIPTION
This is similar to #14, but for the initial token refresh call.

It's not nice, but it works.

```
tap-bing-ads > python ./main.py --config ... --state ...
WARNING oauth error
Traceback (most recent call last):
  File "/Users/wizhi/Code/github.com/dreamdata-io/tap-bing-ads/.direnv/python-3.7.10/lib/python3.7/site-packages/bingads/authorization.py", line 674, in get_access_token
    r.raise_for_status()
  File "/Users/wizhi/Code/github.com/dreamdata-io/tap-bing-ads/.direnv/python-3.7.10/lib/python3.7/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://login.microsoftonline.com/common/oauth2/v2.0/token

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/wizhi/Code/github.com/dreamdata-io/tap-bing-ads/tap_bing_ads/__init__.py", line 1078, in main
    loop.run_until_complete(main_impl())
  File "/Users/wizhi/.pyenv/versions/3.7.10/lib/python3.7/asyncio/base_events.py", line 587, in run_until_complete
    return future.result()
  File "/Users/wizhi/Code/github.com/dreamdata-io/tap-bing-ads/tap_bing_ads/__init__.py", line 1058, in main_impl
    access_token = refresh_access_token()
  File "/Users/wizhi/Code/github.com/dreamdata-io/tap-bing-ads/tap_bing_ads/__init__.py", line 1035, in refresh_access_token
    CONFIG["refresh_token"]
  File "/Users/wizhi/Code/github.com/dreamdata-io/tap-bing-ads/.direnv/python-3.7.10/lib/python3.7/site-packages/bingads/authorization.py", line 469, in request_oauth_tokens_by_refresh_token
    requireliveconnect=self._require_live_connect
  File "/Users/wizhi/Code/github.com/dreamdata-io/tap-bing-ads/.direnv/python-3.7.10/lib/python3.7/site-packages/bingads/authorization.py", line 677, in get_access_token
    raise OAuthTokenRequestException(error_json.get('error'), error_json.get('error_description'))
bingads.exceptions.OAuthTokenRequestException: error_code: invalid_grant, error_description: AADSTS70000: The user could not be authenticated as the grant is expired. The user must sign in again.
Trace ID: bcec8b8a-a7e6-4f72-9e32-1e18fbac0401
Correlation ID: deb40479-8c60-4fd2-b90c-dd8c21a35dc9
Timestamp: 2023-01-16 09:38:01Z
Exception: python exited with 5
[tty 66], line 1: python ./main.py --config ... --state ...
```